### PR TITLE
Make fixes to _get_user_count

### DIFF
--- a/statcord/cluster_client.py
+++ b/statcord/cluster_client.py
@@ -63,19 +63,11 @@ class StatcordClusterClient:
 
     def _get_user_count(self) -> int:
         """Gets the user count of the bot as accurately as it can."""
-
-        if self.bot.intents.members or self.bot.intents.presences:
-            return len(self.bot.users)
-        else:
-            count = 0
-
-            for guild in self.bot.guilds:
-                try:
-                    count += guild.member_count
-                except (AttributeError, ValueError):
-                    pass
-
-            return count
+        return sum([
+            g.member_count for g in self.bot.guilds
+            if hasattr(g, "member_count")
+            and g.member_count is not None
+        ])
 
     async def _command_ran(self, ctx: commands.Context) -> None:
         """Updates command-related statistics."""


### PR DESCRIPTION
This commit does two things:
 1. *Never* use len(bot.guilds), *even* if the members/presence intent is enabled. This is because members intent does not guarantee that the members are actually cached. In fact, in my case, I do not cache (chunk) guilds at startup because that would take a ridiculous amount of memory.
 2. I could be wrong, but I think sum() and list comprehension is faster than a for loop and +=. It still checks if guild.member_count is an actual attribute and it still checks if guild.member_count is None, so it won't break anything.

I tested the code inside of the _get_user_count, but I didn't test this as a whole.

<img width="344" alt="Screen Shot 2021-07-05 at 4 30 59 PM" src="https://user-images.githubusercontent.com/55721663/124515830-63012700-ddae-11eb-966a-8eba1dd2c2d5.png">
