### PR TITLE
Fix _get_user_count and make StatcordClusterClient subclass ClusterClient

### DIFF
--- a/statcord/client.py
+++ b/statcord/client.py
@@ -86,18 +86,11 @@ class StatcordClient:
     def _get_user_count(self) -> int:
         """Gets the user count of the bot as accurately as it can."""
 
-        if self.bot.intents.members or self.bot.intents.presences:
-            return len(self.bot.users)
-        else:
-            count = 0
-
-            for guild in self.bot.guilds:
-                try:
-                    count += guild.member_count
-                except (AttributeError, ValueError):
-                    pass
-
-            return count
+        return sum([
+            g.member_count for g in self.bot.guilds
+            if hasattr(g, "member_count")
+            and g.member_count is not None
+        ])
 
     async def _command_ran(self, ctx: commands.Context) -> None:
         """Updates command-related statistics."""

--- a/statcord/cluster_client.py
+++ b/statcord/cluster_client.py
@@ -32,22 +32,32 @@ class StatcordClusterClient(StatcordClient):
 
         self.logger.debug("Posting stats to Statcord...")
 
-        # get process details
-        mem = psutil.virtual_memory()
-        net_io_counter = psutil.net_io_counters()
-        cpu_load = str(psutil.cpu_percent())
+        # mem stats
+        if self.post_mem_stats:
+            mem = psutil.virtual_memory()
+            mem_used = str(mem.used)
+            mem_load = str(mem.percent)
+        else:
+            mem_used = "0"
+            mem_load = "0"
 
-        # get data ready to send + update old data
-        mem_used = str(mem.used)
-        mem_load = str(mem.percent)
+        # cpu stats
+        if self.post_cpu_stats:
+            cpu_load = str(psutil.cpu_percent())
+        else:
+            cpu_load = "0"
 
-        total_net_usage = net_io_counter.bytes_sent + net_io_counter.bytes_recv  # current net usage
-        period_net_usage = str(total_net_usage - self._prev_net_usage)  # net usage to be sent
-        self._prev_net_usage = total_net_usage  # update previous net usage counter
+        # network stats
+        if self.post_net_stats:
+            net_io_counter = psutil.net_io_counters()
+            total_net_usage = net_io_counter.bytes_sent + net_io_counter.bytes_recv  # current net usage
+            period_net_usage = str(total_net_usage - self._prev_net_usage)  # net usage to be sent
+            self._prev_net_usage = total_net_usage  # update previous net usage counter
+        else:
+            period_net_usage = "0"
 
         data = {
             "id": str(self.bot.user.id),
-            "cluster_id": self.cluster_id,
             "key": self.statcord_key,
             "servers": str(len(self.bot.guilds)),  # server count
             "users": str(self._get_user_count()),  # user count

--- a/statcord/cluster_client.py
+++ b/statcord/cluster_client.py
@@ -13,9 +13,9 @@ class StatcordClusterClient(StatcordClient):
         self,
         bot: commands.Bot,
         statcord_key: str,
-        mem_stats: bool,
-        cpu_stats: bool,
-        net_stats: bool,
+        mem_stats: bool = True,
+        cpu_stats: bool = True,
+        net_stats: bool = True,
     ) -> None:
         super().__init__(
             bot,

--- a/statcord/cluster_client.py
+++ b/statcord/cluster_client.py
@@ -1,12 +1,30 @@
 import psutil
 from collections import defaultdict
 
+from discord.ext import commands
+
 from statcord.client import StatcordClient, HEADERS
 
 STAT_ENDPOINT = "https://api.statcord.com/v3/clusters"
 
 
 class StatcordClusterClient(StatcordClient):
+    def __init__(
+        self,
+        bot: commands.Bot,
+        statcord_key: str,
+        mem_stats: bool,
+        cpu_stats: bool,
+        net_stats: bool,
+    ) -> None:
+        super().__init__(
+            bot,
+            statcord_key,
+            mem_stats=mem_stats,
+            cpu_stats=cpu_stats,
+            net_stats=net_stats
+        )
+
     async def post_stats(self) -> None:
         """Helper method used to actually post the stats to Statcord."""
 

--- a/statcord/cluster_client.py
+++ b/statcord/cluster_client.py
@@ -1,105 +1,12 @@
-from collections import defaultdict
-from discord.ext import commands
-import traceback
-import aiohttp
-import asyncio
-import logging
 import psutil
+from collections import defaultdict
 
-HEADERS = {"Content-Type": "application/json"}
+from statcord.client import StatcordClient, HEADERS
+
 STAT_ENDPOINT = "https://api.statcord.com/v3/clusters"
 
 
-class StatcordClusterClient:
-    """The base Statcord client class for clustered bots."""
-
-    def __init__(self, bot: commands.Bot, statcord_key: str, cluster_id: str) -> None:
-        self.bot = bot
-
-        self.statcord_key = statcord_key
-
-        self.cluster_id = cluster_id
-
-        # validate args
-        if not isinstance(bot, (commands.Bot, commands.AutoShardedBot)):
-            raise TypeError(
-                "The bot argument must be or be a subclass of discord.ext.commands.Bot or discord.ext.commands.AutoShardedBot"
-            )
-
-        if not isinstance(statcord_key, str):
-            raise TypeError("The statcord_key argument must be a string.")
-
-        # setup logging
-        self.logger = logging.getLogger("statcord")
-        self.logger.setLevel(logging.WARNING)
-
-        # create aiohttp clientsession instance
-        self._aiohttp_ses = aiohttp.ClientSession(loop=bot.loop)
-
-        # create counters
-        net_io_counter = psutil.net_io_counters()
-        self._prev_net_usage = net_io_counter.bytes_sent + net_io_counter.bytes_recv
-        self._popular_commands = defaultdict(int)
-        self._command_count = 0
-        self._active_users = set()
-
-        # add on_command handler
-        bot.add_listener(self._command_ran, name="on_command")
-
-        # start stat posting loop
-        self._post_loop_task = bot.loop.create_task(self._post_loop())
-
-    def close(self) -> None:
-        """Closes the Statcord client safely."""
-
-        self._post_loop_task.cancel()
-        self.bot.remove_listener(self._command_ran, name="on_command")
-
-    @staticmethod
-    def _format_traceback(e: Exception) -> str:
-        """Formats exception traceback nicely."""
-
-        return "".join(traceback.format_exception(type(e), e, e.__traceback__, 4))
-
-    def _get_user_count(self) -> int:
-        """Gets the user count of the bot as accurately as it can."""
-
-        if self.bot.intents.members or self.bot.intents.presences:
-            return len(self.bot.users)
-        else:
-            count = 0
-
-            for guild in self.bot.guilds:
-                try:
-                    count += guild.member_count
-                except (AttributeError, ValueError):
-                    pass
-
-            return count
-
-    async def _command_ran(self, ctx: commands.Context) -> None:
-        """Updates command-related statistics."""
-
-        if ctx.command_failed:
-            return
-
-        self._command_count += 1
-        self._active_users.add(ctx.author.id)
-        self._popular_commands[ctx.command.name] += 1
-
-    async def _post_loop(self) -> None:
-        """The stat posting loop which posts stats to the Statcord API."""
-
-        while not self.bot.is_closed():
-            await self.bot.wait_until_ready()
-
-            try:
-                await self.post_stats()
-            except Exception as e:
-                self.logger.error(f"Statcord stat posting error:\n{self._format_traceback(e)}")
-
-            await asyncio.sleep(60)
-
+class StatcordClusterClient(StatcordClient):
     async def post_stats(self) -> None:
         """Helper method used to actually post the stats to Statcord."""
 

--- a/statcord/cluster_client.py
+++ b/statcord/cluster_client.py
@@ -13,6 +13,7 @@ class StatcordClusterClient(StatcordClient):
         self,
         bot: commands.Bot,
         statcord_key: str,
+        cluster_id: str,
         mem_stats: bool = True,
         cpu_stats: bool = True,
         net_stats: bool = True,
@@ -24,6 +25,7 @@ class StatcordClusterClient(StatcordClient):
             cpu_stats=cpu_stats,
             net_stats=net_stats
         )
+        self.cluster_id = cluster_id
 
     async def post_stats(self) -> None:
         """Helper method used to actually post the stats to Statcord."""

--- a/statcord/cluster_client.py
+++ b/statcord/cluster_client.py
@@ -58,6 +58,7 @@ class StatcordClusterClient(StatcordClient):
 
         data = {
             "id": str(self.bot.user.id),
+            "cluster_id": self.cluster_id,
             "key": self.statcord_key,
             "servers": str(len(self.bot.guilds)),  # server count
             "users": str(self._get_user_count()),  # user count


### PR DESCRIPTION
Subclassing the normal client saves code and prevents duplication, and I also fixed _get_user_count.

Allowing users to disable mem/cpu/net stats is useful, especially in the case that clusters are just separate processes on the same server.

Fixing _get_user_count means two things:
 1. Never use len(bot.users), even if the members/presence intent is enabled. This is because members intent does not guarantee that the members are actually cached. In fact, in my case, I do not cache (chunk) guilds at startup because that would take a ridiculous amount of memory.
 2. I could be wrong, but I think sum() and list comprehension is faster than a for loop and +=. It still checks if guild.member_count is an actual attribute and it still checks if guild.member_count is None, so it won't break anything.
I tested the code inside of the _get_user_count, but I didn't test this as a whole.

I tested this as a whole on my bot by installing directly from my repo. Everything worked as expected.